### PR TITLE
Adding configurable TTL to Cloudflare

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -446,7 +446,7 @@ my %variables = (
 		'wildcard'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
 		'mx'	              => setv(T_OFQDN,  0, 1, 1, '',                  undef),
 		'backupmx'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
-		'ttl'		      => setv(T_NUMBER, 1, 0, 1, 1                    undef),
+		'ttl'		      => setv(T_NUMBER, 1, 0, 1, 1,                   undef),
 	},
 	'googledomains-common-defaults'       => {
 		'server'	      => setv(T_FQDNP,  1, 0, 1, 'domains.google.com', undef),
@@ -4112,7 +4112,7 @@ sub nic_cloudflare_update {
 
 			# Set domain
 			$url   = "https://$config{$key}{'server'}/api_json.html?a=rec_edit&type=A";
-			$url	 .= "$ttl=".$config{$key}{'ttl'};
+			$url	 .= "&ttl=".$config{$key}{'ttl'};
 			$url     .= "&name=$hostname";
 			$url     .= "&z=".$config{$key}{'zone'};
 			$url     .= "&id=".$id;	

--- a/sample-etc_ddclient.conf
+++ b/sample-etc_ddclient.conf
@@ -204,7 +204,8 @@ ssl=yes					# use ssl-support.  Works with
 #zone=domain.tld,            \
 #server=www.cloudflare.com,  \
 #login=your-login-email,     \
-#password=APIKey             \
+#password=APIKey,             \
+#ttl=1                       \
 #domain.tld,my.domain.tld
 
 ##


### PR DESCRIPTION
Per title, this change adds configurable TTL to cloudflare instead of just using hardcoded value of 1 which sets "automatic" TTL any time ddclient updates the IP address.