### PR TITLE
Amended: Fixing warnings on FreeDNS update NOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ===============================================================================
-# DDCLIENT v3.8.2
+# DDCLIENT v3.8.3
 
 ddclient is a Perl client used to update dynamic DNS entries for accounts
 on many dynamic DNS services.

--- a/ddclient
+++ b/ddclient
@@ -3704,10 +3704,7 @@ EoEXAMPLE
 ##
 ######################################################################
 sub nic_freedns_update {
-
-
     debug("\nnic_freedns_update -------------------");
-
     ## First get the list of updatable hosts
     my $url;
     $url = "http://$config{$_[0]}{'server'}/api/?action=getdyndns&sha=".&sha1_hex("$config{$_[0]}{'login'}|$config{$_[0]}{'password'}");
@@ -3733,34 +3730,36 @@ sub nic_freedns_update {
 	info("setting IP address to %s for %s", $ip, $h);
 	verbose("UPDATE:","updating %s", $h);
 
-	if($ip eq $freedns_hosts{$h}->[1]) { 
-	    $config{$h}{'ip'}     = $ip; 
-	    $config{$h}{'mtime'}  = $now; 
-	    $config{$h}{'status'} = 'good'; 
-	    success("update not necessary %s: good: IP address already set to %s", $h, $ip); 
-	} else {
-	    my $reply = geturl(opt('proxy'), $freedns_hosts{$h}->[2]);
-	    if (!defined($reply) || !$reply) {
-	        failed("updating %s: Could not connect to %s.", $h, $freedns_hosts{$h}->[2]);
-		last;
-	    }
-	    if(!header_ok($h, $reply)) { 
-		$config{$h}{'status'} = 'failed'; 
-		last; 
-	    }
+        if($ip eq $freedns_hosts{$h}->[1]) { 
+            $config{$h}{'ip'}     = $ip; 
+            $config{$h}{'mtime'}  = $now; 
+            $config{$h}{'status'} = 'good'; 
+            success("update not necessary %s: good: IP address already set to %s", $h, $ip); 
+        } else {
+            my $reply = geturl(opt('proxy'), $freedns_hosts{$h}->[2]);
+            if (!defined($reply) || !$reply) {
+                failed("updating %s: Could not connect to %s.", $h, $freedns_hosts{$h}->[2]);
+                last;
+            }
+            if(!header_ok($h, $reply)) { 
+                $config{$h}{'status'} = 'failed'; 
+                last; 
+            }
 
-	    if($reply =~ /Updated.*$h.*to.*$ip/) { 
-		$config{$h}{'ip'}     = $ip; 
-		$config{$h}{'mtime'}  = $now; 
-		$config{$h}{'status'} = 'good'; 
-		success("updating %s: good: IP address set to %s", $h, $ip); 
-	    } else {
-	        $config{$h}{'status'} = 'failed';
-		warning("SENT: %s", $freedns_hosts{$h}->[2]) unless opt('verbose');
-		warning("REPLIED: %s", $reply);
-		failed("updating %s: Invalid reply.", $h);
-	    }
-	}
+            if($reply =~ /Updated.*$h.*to.*$ip/) { 
+                $config{$h}{'ip'}     = $ip; 
+                $config{$h}{'mtime'}  = $now; 
+                $config{$h}{'status'} = 'good'; 
+                success("updating %s: good: IP address set to %s", $h, $ip); 
+            } elsif ($reply =~ /Address .* has not changed/) {
+                success("updating %s: good: IP address has not changed", $h, $ip);
+            } else {
+                $config{$h}{'status'} = 'failed';
+                warning("SENT: %s", $freedns_hosts{$h}->[2]) unless opt('verbose');
+                warning("REPLIED: %s", $reply);
+                failed("updating %s: Invalid reply.", $h);
+            }
+        }
     }
 }
 

--- a/ddclient
+++ b/ddclient
@@ -3730,29 +3730,33 @@ sub nic_freedns_update {
 	info("setting IP address to %s for %s", $ip, $h);
 	verbose("UPDATE:","updating %s", $h);
 
-        if($ip eq $freedns_hosts{$h}->[1]) { 
-            $config{$h}{'ip'}     = $ip; 
-            $config{$h}{'mtime'}  = $now; 
-            $config{$h}{'status'} = 'good'; 
-            success("update not necessary %s: good: IP address already set to %s", $h, $ip); 
+        if($ip eq $freedns_hosts{$h}->[1]) {
+            $config{$h}{'ip'}     = $ip;
+            $config{$h}{'mtime'}  = $now;
+            $config{$h}{'status'} = 'good';
+            success("update not necessary %s: good: IP address already set to %s", $h, $ip);
         } else {
             my $reply = geturl(opt('proxy'), $freedns_hosts{$h}->[2]);
             if (!defined($reply) || !$reply) {
                 failed("updating %s: Could not connect to %s.", $h, $freedns_hosts{$h}->[2]);
                 last;
             }
-            if(!header_ok($h, $reply)) { 
-                $config{$h}{'status'} = 'failed'; 
+            if(!header_ok($h, $reply)) {
+                $config{$h}{'status'} = 'failed';
                 last; 
             }
 
-            if($reply =~ /Updated.*$h.*to.*$ip/) { 
-                $config{$h}{'ip'}     = $ip; 
-                $config{$h}{'mtime'}  = $now; 
-                $config{$h}{'status'} = 'good'; 
-                success("updating %s: good: IP address set to %s", $h, $ip); 
-            } elsif ($reply =~ /Address .* has not changed/) {
-                success("updating %s: good: IP address has not changed", $h, $ip);
+            if($reply =~ /Updated.*$h.*to.*$ip/) {
+                $config{$h}{'ip'}     = $ip;
+                $config{$h}{'mtime'}  = $now;
+                $config{$h}{'status'} = 'good';
+                success("updating %s: good: IP address set to %s", $h, $ip);
+            } elsif ($reply =~ /Address (\d+\.\d+\.\d+\.\d+) has not changed/) {
+                $ip = $1;
+                $config{$h}{'mtime'}  = $now;
+                $config{$h}{'status'} = 'good';
+                $config{$h}{'ip'}     = $ip;
+                success("updating %s: good: IP address %s has not changed", $h, $ip);
             } else {
                 $config{$h}{'status'} = 'failed';
                 warning("SENT: %s", $freedns_hosts{$h}->[2]) unless opt('verbose');


### PR DESCRIPTION
Amended pull request of #30.  

When FreeDNS was updating, I was noticing that it would send back an HTTP 200 with the text "Address [IP] has not changed", but ddclient was issuing a failed status for this and logging a ton of text to syslog. I changed the function a tiny bit to allow this to be a success status.