### PR TITLE
Cloudflare Config

### DIFF
--- a/sample-etc_ddclient.conf
+++ b/sample-etc_ddclient.conf
@@ -200,7 +200,6 @@ ssl=yes					# use ssl-support.  Works with
 ##
 #protocol=cloudflare,        \
 #zone=domain.tld,            \
-#server=www.cloudflare.com,  \
 #login=your-login-email,     \
 #password=APIKey,             \
 #ttl=1                       \


### PR DESCRIPTION
Specifying the `server` directive caused the Cloudflare protocol to use the wrong url when communicating with Cloudflare API v4. It works if the directive is removed.

Changes:
- Update sample config with functional Cloudflare settings. 
