### PR TITLE
Interpret 'Address not changed' reply from freedns and tidy up indents.

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -3841,6 +3841,12 @@ sub nic_freedns_update {
 		$config{$h}{'mtime'}  = $now; 
 		$config{$h}{'status'} = 'good'; 
 		success("updating %s: good: IP address set to %s", $h, $ip); 
+	    } elsif ($reply =~ /ERROR: Address (.*) has not changed\./) {
+		$ip = $1;
+		$config{$h}{'ip'}     = $ip; 
+		$config{$h}{'mtime'}  = $now; 
+		$config{$h}{'status'} = 'good'; 
+		success("update not necessary %s: IP address already set to %s", $h, $ip); 
 	    } else {
 	        $config{$h}{'status'} = 'failed';
 		warning("SENT: %s", $freedns_hosts{$h}->[2]) unless opt('verbose');


### PR DESCRIPTION
Freedns appears to have changed the response when an update attempt is made but the address has not changed, returning an error. This interprets the error response.